### PR TITLE
Add a debouncer to limit unnecessay config reloads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/pluies/config-reloader-sidecar/v2
 go 1.21
 
 require (
-	github.com/fsnotify/fsnotify v1.6.0
+	github.com/bep/debounce v1.2.1
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/mitchellh/go-ps v1.0.0
-	golang.org/x/sys v0.6.0
+	golang.org/x/sys v0.24.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,8 @@
-github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
-github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
+github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
+golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	delay, _ := time.ParseDuration("0")
-	delayFlag := os.Getenv("DELAY")
+	delayFlag := os.Getenv("DEBOUNCER_DELAY")
 	if delayFlag != "" {
 		delayDuration, err := time.ParseDuration(delayFlag)
 		if err != nil {
@@ -55,7 +55,7 @@ func main() {
 		}
 	}
 
-	log.Printf("starting with CONFIG_DIR=%s, PROCESS_NAME=%s, RELOAD_SIGNAL=%s, DELAY=%s\n", configDir, processName, reloadSignal, delay)
+	log.Printf("starting with CONFIG_DIR=%s, PROCESS_NAME=%s, RELOAD_SIGNAL=%s, DEBOUNCER_DELAY=%s\n", configDir, processName, reloadSignal, delay)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"strings"
 	"syscall"
+	"time"
 
+	"github.com/bep/debounce"
 	"github.com/fsnotify/fsnotify"
 	"github.com/mitchellh/go-ps"
 	"golang.org/x/sys/unix"
@@ -29,6 +31,18 @@ func main() {
 		verbose = true
 	}
 
+	delay, _ := time.ParseDuration("0")
+	delayFlag := os.Getenv("DELAY")
+	if delayFlag != "" {
+		delayDuration, err := time.ParseDuration(delayFlag)
+		if err != nil {
+			log.Fatal(err)
+		}
+		delay = delayDuration
+	}
+
+	debounced := debounce.New(delay)
+
 	var reloadSignal syscall.Signal
 	reloadSignalStr := os.Getenv("RELOAD_SIGNAL")
 	if reloadSignalStr == "" {
@@ -41,7 +55,7 @@ func main() {
 		}
 	}
 
-	log.Printf("starting with CONFIG_DIR=%s, PROCESS_NAME=%s, RELOAD_SIGNAL=%s\n", configDir, processName, reloadSignal)
+	log.Printf("starting with CONFIG_DIR=%s, PROCESS_NAME=%s, RELOAD_SIGNAL=%s, DELAY=%s\n", configDir, processName, reloadSignal, delay)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Fatal(err)
@@ -61,10 +75,13 @@ func main() {
 				}
 				if event.Op&fsnotify.Chmod != fsnotify.Chmod {
 					log.Println("modified file:", event.Name)
-					err := reloadProcess(processName, reloadSignal)
-					if err != nil {
-						log.Println("error:", err)
-					}
+
+					debounced(func() {
+						err := reloadProcess(processName, reloadSignal)
+						if err != nil {
+							log.Println("error:", err)
+						}
+					})
 				}
 			case err, ok := <-watcher.Errors:
 				if !ok {

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	delay, _ := time.ParseDuration("0")
-	delayFlag := os.Getenv("DEBOUNCER_DELAY")
+	delayFlag := os.Getenv("DEBOUNCE_DELAY")
 	if delayFlag != "" {
 		delayDuration, err := time.ParseDuration(delayFlag)
 		if err != nil {
@@ -55,7 +55,7 @@ func main() {
 		}
 	}
 
-	log.Printf("starting with CONFIG_DIR=%s, PROCESS_NAME=%s, RELOAD_SIGNAL=%s, DEBOUNCER_DELAY=%s\n", configDir, processName, reloadSignal, delay)
+	log.Printf("starting with CONFIG_DIR=%s, PROCESS_NAME=%s, RELOAD_SIGNAL=%s, DEBOUNCE_DELAY=%s\n", configDir, processName, reloadSignal, delay)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This will add the ability to delay `DEBOUNCER_DELAY` seconds before triggering a config reload when a file changes.